### PR TITLE
expand Syntax section

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -356,8 +356,21 @@ Specification
 Syntax
 ------
 
-An intersection of types `A` and `B` should be defined using the operator `A & B`, or
-`Intersection[A, B]` when programmatically generating intersections.
+An intersection of types ``A`` and ``B`` should be defined using the operator ``A & B``, or
+``Intersection[A, B]`` when programmatically generating intersections.
+
+Note that the use of the ampersand(``&``) operator in this context requires a grammar change,
+and is therefore available only in new versions of Python.
+To enable use of intersection types in older versions of Python, we introduce the ``Intersection``
+type operator that can be used in place of the ampersand operator:
+
+::
+
+    # generating intersections using the ampersand operator in new versions of Python
+    def f(value: A & B): ...
+
+    # generating intersections using `Intersection` in older versions of Python
+    def f(value: Intersection[A, B]): ...
 
 
 Order and Emptiness


### PR DESCRIPTION
As discussed in #9, it's necessary to mention that `Intersection` is available as an alternative due to the inability to use the `&` operator for typing in older versions of Python.

I wrote this in a similar style to [introduce `Unpack` in PEP646](https://peps.python.org/pep-0646/#unpack-for-backwards-compatibility).